### PR TITLE
use latest version of xml2json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "rest": "~1.0.0",
-    "xml2json": "~0.3.2"
+    "xml2json": "~0.6.1"
   }
 }


### PR DESCRIPTION
The module cannot be built with the old version of xml2json if the latest version of expat is installed on the system. This problem is solved by using the latest version of xml2json.
