### PR TITLE
Pass options to interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ npm install bgg
 ## Usage
 
 ```javascript
+// all options are optional
 var options = {
-  timeout: 10000, // timeout in 10s
+  timeout: 10000, // timeout of 10s (5s is the default)
 
   // see https://github.com/cujojs/rest/blob/master/docs/interceptors.md#module-rest/interceptor/retry
   retry: {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@ npm install bgg
 ## Usage
 
 ```javascript
-var bgg = require('bgg');
+var options = {
+  timeout: 10000, // timeout in 10s
+
+  // see https://github.com/cujojs/rest/blob/master/docs/interceptors.md#module-rest/interceptor/retry
+  retry: {
+    initial: 100,
+    multiplier: 2,
+    max: 15e3
+  }
+}
+
+var bgg = require('bgg')(options);
 
 bgg('user', {name: 'monteslu', guilds: 1})
   .then(function(results){

--- a/index.js
+++ b/index.js
@@ -8,13 +8,15 @@ var retryInterceptor = require('rest/interceptor/retry');
 var timeoutInterceptor = require('rest/interceptor/timeout');
 
 module.exports = function(config) {
+
+  var config = config || {};
   
-var restCall = rest
-  .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
-  .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
-  .wrap(errorCodeInterceptor)
-  .wrap(interceptor)
-  .wrap(timeoutInterceptor, { timeout: config.timeout || 5000 });
+  var restCall = rest
+    .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
+    .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
+    .wrap(errorCodeInterceptor)
+    .wrap(interceptor)
+    .wrap(timeoutInterceptor, { timeout: config.timeout || 5000 });
   
   if(config.retry) {
     restCall = restCall.wrap(retryInterceptor, config.retry);

--- a/index.js
+++ b/index.js
@@ -3,20 +3,29 @@ var interceptor = require('./interceptor');
 
 var errorCodeInterceptor = require('rest/interceptor/errorCode');
 var pathPrefixInterceptor = require('rest/interceptor/pathPrefix');
-var entityInterceptor = require('rest/interceptor/entity');
 var mimeInterceptor = require('rest/interceptor/mime');
+var retryInterceptor = require('rest/interceptor/retry');
+var timeoutInterceptor = require('rest/interceptor/timeout');
 
+module.exports = function(config) {
+  
 var restCall = rest
-  .chain(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
-  .chain(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
-  .chain(interceptor)
-  .chain(entityInterceptor)
-  .chain(errorCodeInterceptor);
-
-module.exports = function(path, params){
-  var restConfig = {path: path};
-  if(params){
-    restConfig.params = params;
+  .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
+  .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
+  .wrap(errorCodeInterceptor)
+  .wrap(interceptor)
+  .wrap(timeoutInterceptor, { timeout: config.timeout || 5000 });
+  
+  if(config.retry) {
+    restCall = restCall.wrap(retryInterceptor, config.retry);
   }
-  return restCall(restConfig);
-};
+  
+  return function(path, params){
+    var restConfig = {path: path};
+    if(params){
+      restConfig.params = params;
+    }
+    return restCall(restConfig);
+  };
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bgg",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "BoardGameGeek.com API client",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "url": "https://github.com/monteslu/bgg/issues"
   },
   "dependencies": {
-    "rest": "~1.0.0",
+    "rest": "~1.3.1",
     "xml2json": "~0.6.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var bgg = require('../');
+var bgg = require('../')();
 
 var log = console.log.bind(console);
 var error = console.error.bind(console);


### PR DESCRIPTION
BGG very frequently responds with an error 503. With this update, it's now possible to configure an automatic retry of failed requests. For the configuration of the retries, the same settings as for the [rest retry interceptor](https://github.com/cujojs/rest/blob/master/docs/interceptors.md#module-rest/interceptor/retry) apply.

I also updated rest to the newest version.

This is a breaking change, so I changed the version to 1.0.0.
