### PR TITLE
Allowing toJSON options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var options = {
     max: 15e3
   },
 
-  interceptorConfig: {object: true, sanitize: false} //Optional xml2json.toJSON options
+  toJSONConfig: {object: true, sanitize: false} //Optional xml2json.toJSON options
 }
 
 var bgg = require('bgg')(options);

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ var options = {
     initial: 100,
     multiplier: 2,
     max: 15e3
-  }
+  },
+
+  interceptorConfig: {object: true, sanitize: false} //Optional xml2json.toJSON options
 }
 
 var bgg = require('bgg')(options);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var rest = require('rest');
-var interceptor = require('./interceptor');
+
 
 var errorCodeInterceptor = require('rest/interceptor/errorCode');
 var pathPrefixInterceptor = require('rest/interceptor/pathPrefix');
@@ -10,18 +10,18 @@ var timeoutInterceptor = require('rest/interceptor/timeout');
 module.exports = function(config) {
 
   var config = config || {};
-  
+  var interceptor = require('./interceptor')(config.interceptorConfig || null);
   var restCall = rest
     .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
     .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
     .wrap(errorCodeInterceptor)
     .wrap(interceptor)
     .wrap(timeoutInterceptor, { timeout: config.timeout || 5000 });
-  
+
   if(config.retry) {
     restCall = restCall.wrap(retryInterceptor, config.retry);
   }
-  
+
   return function(path, params){
     var restConfig = {path: path};
     if(params){
@@ -30,4 +30,3 @@ module.exports = function(config) {
     return restCall(restConfig);
   };
 }
-

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var timeoutInterceptor = require('rest/interceptor/timeout');
 module.exports = function(config) {
 
   var config = config || {};
-  var interceptor = require('./interceptor')(config.interceptorConfig || null);
+  var interceptor = require('./interceptor')(config.toJSONConfig || null);
   var restCall = rest
     .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})
     .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ var mimeInterceptor = require('rest/interceptor/mime');
 var retryInterceptor = require('rest/interceptor/retry');
 var timeoutInterceptor = require('rest/interceptor/timeout');
 
-module.exports = function(config) {
+module.exports = function(_config) {
 
-  var config = config || {};
+  var config = _config || {};
   var interceptor = require('./interceptor')(config.toJSONConfig || null);
   var restCall = rest
     .wrap(pathPrefixInterceptor, { prefix: 'http://www.boardgamegeek.com/xmlapi2/'})

--- a/interceptor.js
+++ b/interceptor.js
@@ -1,10 +1,16 @@
 var interceptor = require('rest/interceptor');
 var parser = require('xml2json');
 
-var parserConfig = {object: true};
+var defaultConfig = {object: true};
 
-module.exports = interceptor({
-  success: function(response, config, client){
-    return parser.toJson(response.entity, parserConfig);
-  }
-});
+var interceptorSetup = function(cfg){
+  var parserConfig = cfg || defaultConfig;
+
+  return interceptor({
+    success: function(response, config, client){
+      return parser.toJson(response.entity, parserConfig);
+    }
+  });
+};
+
+module.exports = interceptorSetup;


### PR DESCRIPTION
Hi,

I had issues with the display of the game descriptions with Angular and found that turning off the XML2JSON sanitisation and handling it in Angular resolved the issue because the BGG XMLAPI2 response already seems sanitised.

 e.g. it was santising `&#10;&#10;` to `&amp;&amp;#35;#10;&amp;&amp;#35;10;` .

This PR just allows the XML2JSON toJSON options to be set in app rather than in the node module but shouldn't affect normal usage.

(This is my first PR, so let me know if I'm off the mark)

Thanks!

Jarryd
