### PR TITLE
Update BGG API base domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,18 +10,18 @@ var timeoutInterceptor = require('rest/interceptor/timeout');
 module.exports = function(config) {
 
   var config = config || {};
-  
+
   var restCall = rest
-    .wrap(pathPrefixInterceptor, { prefix: 'https://www.boardgamegeek.com/xmlapi2/'})
+    .wrap(pathPrefixInterceptor, { prefix: 'https://api.geekdo.com/xmlapi2/'})
     .wrap(mimeInterceptor, {mime:'text/xml', accept: 'text/xml'})
     .wrap(errorCodeInterceptor)
     .wrap(interceptor)
     .wrap(timeoutInterceptor, { timeout: config.timeout || 5000 });
-  
+
   if(config.retry) {
     restCall = restCall.wrap(retryInterceptor, config.retry);
   }
-  
+
   return function(path, params){
     var restConfig = {path: path};
     if(params){


### PR DESCRIPTION
The BGG API lives now under https://api.geekdo.com/xmlapi2/

This commit updates the base URL so the client works again.