### PR TITLE
fix: Detect 202 status when BGG queues collection requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,16 @@ export default function createClient(config = {}) {
         headers: { 'Accept': 'text/xml' }
       });
 
+      // Handle 202 Accepted - BGG queues collection requests
+      // Return a special object so callers can detect and retry
+      if (response.status === 202) {
+        return {
+          _queued: true,
+          _status: 202,
+          _message: 'Request queued by BGG. Retry after a short delay.'
+        };
+      }
+
       if (!response.ok) {
         throw new Error(`BGG API error: ${response.status} ${response.statusText}`);
       }


### PR DESCRIPTION
Closes #2

## Problem

BGG returns HTTP 202 Accepted when a collection request is queued for processing (common for large collections). The library was treating this as an error.

## Solution

Return a special object when status is 202:

```javascript
{
  _queued: true,
  _status: 202,
  _message: "Request queued by BGG. Retry after a short delay."
}
```

Callers can check for `result._queued` and retry after a delay:

```javascript
const result = await bgg("collection", { username: "someone" });
if (result._queued) {
  // Wait and retry
  await new Promise(r => setTimeout(r, 2000));
  return bgg("collection", { username: "someone" });
}
```

This is a non-breaking change - existing code that doesn"t check for _queued will just see an object without the expected BGG data.